### PR TITLE
Исправил svg и добавил линтинг стилей

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "comment-whitespace-inside": "never",
+    "declaration-block-semicolon-space-before": null,
+    "declaration-colon-newline-after": "always-multi-line",
+    "declaration-empty-line-before": null,
+    "declaration-no-important": true,
+    "declaration-property-value-blacklist": {
+      "display": "table",
+      "position": "absolute"
+    },
+    "selector-no-id": true
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,4 +34,5 @@ gulp.task("serve", ["style"], function() {
 
   gulp.watch("postcss/**/*.css", ["style"]);
   gulp.watch("*.html").on("change", server.reload);
+  gulp.watch("img/*.svg").on("change", server.reload);
 });

--- a/img/bg-intro-triangle-desktop.svg
+++ b/img/bg-intro-triangle-desktop.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1199.91px" height="57px" viewBox="0 0 1199.91 57" enable-background="new 0 0 1199.91 57" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1199.91px" height="57px" viewBox="1 0 1199 57" enable-background="new 0 0 1199.91 57" xml:space="preserve">
   <g>
     <polygon fill="#FFFFFF" points="250.08,23.71 0.514,0 0.514,57 250.08,57 600.469,57 250.08,0"/>
     <polygon fill="#FFFFFF" points="950.859,23.71 950.859,0 600.469,57 950.859,57 1200.424,57 1200.424,0"/>

--- a/img/bg-intro-triangle-mobile.svg
+++ b/img/bg-intro-triangle-mobile.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="320px" height="26.111px" viewBox="440.469 30.889 320 26.111" enable-background="new 440.469 30.889 320 26.111" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="320px" height="26.111px" viewBox="440.469 30.889 320 26" enable-background="new 440.469 30.889 320 26.111" xml:space="preserve">
   <polygon fill="#FFFFFF" points="760.469,57 760.469,30.889 599.955,57"/>
   <polygon fill="#FFFFFF" points="440.469,57 599.955,57 440.469,31.056"/>
 </svg>

--- a/package.json
+++ b/package.json
@@ -13,18 +13,21 @@
   },
   "homepage": "https://github.com/htmlacademy-adaptive/202785-sedona",
   "devDependencies": {
+    "@htmlacademy/editorconfig-cli": "0.0.7",
     "autoprefixer": "6.4.1",
     "browser-sync": "2.15.0",
     "gulp": "3.9.1",
     "gulp-plumber": "1.1.0",
     "gulp-postcss": "6.2.0",
-    "@htmlacademy/editorconfig-cli": "0.0.7",
-    "precss": "1.4.0"
+    "precss": "1.4.0",
+    "stylelint": "^7.3.1",
+    "stylelint-config-standard": "^13.0.2"
   },
   "scripts": {
     "test": "editorconfig-cli",
     "build": "gulp style",
-    "start": "gulp serve"
+    "start": "gulp serve",
+    "test:styles": "stylelint postcss/**/*.css"
   },
   "editorconfig-cli": [
     "*.html",


### PR DESCRIPTION
Линтинг запускается командой `npm run test:styles`. Потом, когда привыкнешь, можно будет его привязать и к команде `npm test`, чтобы каждый раз при коммите и пулл запросе происходило автоматическое тестирование на travis-ci.org
Подробнее о правилах можно посмотреть тут http://stylelint.io/user-guide/rules/. Это пригодится, когда будешь анализировать ошибки.
